### PR TITLE
Application should not exit if passwords do not match during file encryption

### DIFF
--- a/cryptogo.go
+++ b/cryptogo.go
@@ -61,19 +61,24 @@ func encryptHandle() {
 		panic("File not found")
 	}
 
-	fmt.Print("Enter password: ")
-	password, _ := terminal.ReadPassword(0)
-	fmt.Print("\nConfirm password: ")
-	password2, _ := terminal.ReadPassword(0)
-
-	if !validatePassword(password, password2) {
-		panic("Passwords do not match")
-	}
+	password := getPassword()
 
 	fmt.Println("\nEncrypting...")
 	filecrypt.Encrypt(file, password)
 	fmt.Println("\nFile successfully protected")
 
+}
+
+func getPassword() []byte {
+	fmt.Print("Enter password: ")
+	password, _ := terminal.ReadPassword(0)
+	fmt.Print("\nConfirm password: ")
+	password2, _ := terminal.ReadPassword(0)
+	if !validatePassword(password, password2) {
+		fmt.Print("\nPasswords do not match. Please try again.\n")
+		return getPassword()
+	}
+	return password
 }
 
 func decryptHandle() {


### PR DESCRIPTION
Resolve #1 by adding a new method that will recursively prompt users for their passwords if they enter non matching passwords during file encryption. A limit could be added to the recursion to avoid stack overflow, but it is hard for me to see a user messing up the password that many times. That's your call though, I can add it if you want.